### PR TITLE
Message when the number of disruptions changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
     "@types/dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-vUWIRMuCraBH+oekdScK1VSS0tQ="
+      "integrity": "sha1-vUWIRMuCraBH+oekdScK1VSS0tQ=",
+      "dev": true
     },
     "@types/form-data": {
       "version": "0.0.33",
@@ -35,7 +36,14 @@
     "@types/node": {
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.11.tgz",
-      "integrity": "sha512-cvpf//OAWDUtIjkPvxBJLpv3J8+961gJU0rdmMSWEbkCsn3ql66BP5He8laiqicfocRsegq3DEOu0IMMMhFjzg=="
+      "integrity": "sha512-cvpf//OAWDUtIjkPvxBJLpv3J8+961gJU0rdmMSWEbkCsn3ql66BP5He8laiqicfocRsegq3DEOu0IMMMhFjzg==",
+      "dev": true
+    },
+    "@types/pluralize": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.27.tgz",
+      "integrity": "sha1-CHNUp5HOAn2xEB/zmdthEfySdfc=",
+      "dev": true
     },
     "@types/request": {
       "version": "0.0.46",
@@ -569,6 +577,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "pluralize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-6.0.0.tgz",
+      "integrity": "sha1-2bUa+tl9PVEHXMHdupsTLKzMt7o="
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -26,19 +26,21 @@
   },
   "homepage": "https://github.com/adamkelsall/slack-metro#readme",
   "dependencies": {
-    "@types/dotenv": "^4.0.0",
     "chalk": "^2.0.1",
     "cheerio": "^1.0.0-rc.1",
     "dotenv": "^4.0.0",
     "moment-timezone": "^0.5.13",
+    "pluralize": "^6.0.0",
     "reflect-metadata": "^0.1.10",
     "request": "^2.81.0"
   },
   "devDependencies": {
     "@types/chalk": "^0.4.31",
     "@types/cheerio": "^0.22.2",
+    "@types/dotenv": "^4.0.0",
     "@types/moment-timezone": "^0.2.34",
     "@types/node": "^8.0.11",
+    "@types/pluralize": "0.0.27",
     "@types/request": "0.0.46",
     "ts-node": "^3.2.0",
     "tslint": "^5.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,13 @@ async function processMetroDisruptions(): Promise<void> {
     const disruptions: Cheerio = getDisruptions(metroPage);
 
     const persistedData: PersistedData = await readPersistedData();
-    if (!persistedData.lastWasDisruption && disruptions.length) {
-      const message = createSlackMessage(disruptions);
+    if (persistedData.disruptions !== disruptions.length) {
+      const message = createSlackMessage(persistedData.disruptions, disruptions);
       await postToSlack(config.slackWebhookUrl, message);
     }
 
     await writePersistedData({
-      lastWasDisruption: Boolean(disruptions.length),
+      disruptions: disruptions.length,
     });
 
   } catch (err) {

--- a/src/output/createSlackMessage.ts
+++ b/src/output/createSlackMessage.ts
@@ -32,7 +32,7 @@ export function createSlackMessage(previousCount: number, disruptions: Cheerio):
 
       return attachment;
     });
-  };
+  }
 
   return message;
 }

--- a/src/output/createSlackMessage.ts
+++ b/src/output/createSlackMessage.ts
@@ -7,7 +7,6 @@ import { Disruption, formatDisruption } from "../input";
 
 export function createSlackMessage(previousCount: number, disruptions: Cheerio): SlackMessage {
   const message: SlackMessage = {
-    channel: "@adamkelsall", // TODO remove
     text: textForCount(previousCount, disruptions.length),
   };
 

--- a/src/output/createSlackMessage.ts
+++ b/src/output/createSlackMessage.ts
@@ -1,18 +1,24 @@
 import * as moment from "moment-timezone";
 import { Moment } from "moment-timezone";
+import * as pluralize from "pluralize";
 
 import { SlackMessage, SlackMessageAttachment } from ".";
 import { Disruption, formatDisruption } from "../input";
 
-export function createSlackMessage(disruptions: Cheerio): SlackMessage {
-  const formattedDisruptions: Disruption[] = [];
-
-  disruptions.each((index, disruption) => {
-    formattedDisruptions.push(formatDisruption(disruption));
-  });
-
+export function createSlackMessage(previousCount: number, disruptions: Cheerio): SlackMessage {
   const message: SlackMessage = {
-    attachments: formattedDisruptions.map((disruption, index) => {
+    channel: "@adamkelsall", // TODO remove
+    text: textForCount(previousCount, disruptions.length),
+  };
+
+  if (disruptions.length) {
+    const formattedDisruptions: Disruption[] = [];
+
+    disruptions.each((index, disruption) => {
+      formattedDisruptions.push(formatDisruption(disruption));
+    });
+
+    message.attachments = formattedDisruptions.map((disruption, index) => {
       const lines = disruption.lines.join("\n");
       const updated: Moment = moment(disruption.updated);
       const time: string = updated.format("H:mma");
@@ -25,9 +31,35 @@ export function createSlackMessage(disruptions: Cheerio): SlackMessage {
       };
 
       return attachment;
-    }),
-    text: "One or more disruptions have been detected following a period where there were none :frowning:",
+    });
   };
 
   return message;
+}
+
+function textForCount(previousCount: number, count: number): string {
+  if (!count) {
+    return `There are no longer any disruptions! ${emojiForCount(count)}`;
+  }
+
+  const pluralAre = pluralize("is", count);
+  const pluralDisruption = pluralize("disruption", count);
+  const direction = previousCount < count ? "up" : "down";
+  const emoji = emojiForCount(count);
+
+  return `There ${pluralAre} now ${count} ${pluralDisruption}, ${direction} from ${previousCount} ${emoji}`;
+}
+
+function emojiForCount(count: number): string {
+  const emojis = [
+    ":smile: :tada:",
+    ":worried:",
+    ":anguished:",
+    ":persevere:",
+    ":cold_sweat:",
+    ":scream:",
+    ":upside_down_face:",
+  ];
+
+  return count > 5 ? emojis[6] : emojis[count];
 }

--- a/src/persist/index.ts
+++ b/src/persist/index.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 export interface PersistedData {
-  lastWasDisruption: boolean;
+  disruptions: number;
 }
 
 export function readPersistedData(): Promise<PersistedData> {
@@ -10,7 +10,7 @@ export function readPersistedData(): Promise<PersistedData> {
     fs.readFile(persistedFile(), (err, data) => {
       if (err) {
         const defaultData: PersistedData = {
-          lastWasDisruption: false,
+          disruptions: 0,
         };
 
         return /ENOENT/.test(err.message) ? resolve(defaultData) : reject(err);


### PR DESCRIPTION
Currently a message is only sent to Slack when the number of delays increases from 0. This PR changes this to a message any time the number of delays changes.

- Specific message for down to 0 delays, including :tada: emoji!
- Messages show previous and current count.
- Correct pluralisation of words.
- Different emojis depending on the number of delays.