### PR TITLE
Remove line breaks from disruptions text

### DIFF
--- a/src/input/formatDisruption.ts
+++ b/src/input/formatDisruption.ts
@@ -11,7 +11,6 @@ export function formatDisruption(disruption: CheerioElement): Disruption {
   const lines: string[] = [];
 
   $(disruption).children("p").each((index: number, paragraph: CheerioElement) => {
-    const whitespaces: RegExp = /\s+/g;
     const line: string = collapseWhitespace($(paragraph).text()).trim();
     lines.push(line);
   });

--- a/src/input/formatDisruption.ts
+++ b/src/input/formatDisruption.ts
@@ -30,6 +30,9 @@ function formatUpdatedDate(element: Cheerio): Date {
 }
 
 function collapseWhitespace(text: string): string {
-  const whitespaces: RegExp = /\s+/g;
-  return text.replace(whitespaces, " ");
+  const whiteSpaces: RegExp = /\s+/g;
+  const lineBreaks: RegExp = /<br[ /]*>/i;
+
+  return text.replace(lineBreaks, "").replace(whiteSpaces, " ");
 }
+


### PR DESCRIPTION
Metro disruptions often have `<br />` tags that split paragraphs. Slack parses HTML so this doesn't output raw HTML, but it does act as intended.

This PR removes line breaks so that text can fit on the screen however it likes.